### PR TITLE
Future-proof comparison of pip version

### DIFF
--- a/lib/poise_python/resources/python_package.rb
+++ b/lib/poise_python/resources/python_package.rb
@@ -38,7 +38,7 @@ import sys
 
 import pip
 # Don't use pkg_resources because I don't want to require it before this anyway.
-if re.match(r'0|1|6\\.0', pip.__version__):
+if re.match(r'^(0|1\\.|6\\.0)', pip.__version__):
   sys.stderr.write('The python_package resource requires pip >= 6.1.0, currently '+pip.__version__+'\\n')
   sys.exit(1)
 


### PR DESCRIPTION
When checking pip version in python_package, check version more
strictly. This will make it future-proof against pip versions >= 10.